### PR TITLE
Deactivate tests that require expo token on PRs

### DIFF
--- a/.github/workflows/maestro-ios-cloud.yml
+++ b/.github/workflows/maestro-ios-cloud.yml
@@ -1,8 +1,6 @@
 name: Maestro iOS - Cloud
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   push:
     branches:
       - main

--- a/.github/workflows/maestro-ios-selfhosted.yml
+++ b/.github/workflows/maestro-ios-selfhosted.yml
@@ -1,8 +1,6 @@
 name: Maestro iOS - Self-Hosted
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   push:
     branches:
       - main

--- a/.github/workflows/maestro-web.yml
+++ b/.github/workflows/maestro-web.yml
@@ -1,8 +1,6 @@
 name: Maestro Web
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   push:
     branches:
       - main


### PR DESCRIPTION
We are running Dependabot on this public repo, but the PRs opened by Dependabot don't have access to EXPO_TOKEN, because it would be a security risk. Instead, we'll just run the Maestro tests on main, not on PRs.