### PR TITLE
Fix web deploy directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
   command = "yarn build:web"
 
 [context.production]
-  publish = "web-build/"
+  publish = "dist/"


### PR DESCRIPTION
When we changed from Webpack to Metro for web builds, we missed the change to the directory that Netlify deploys from